### PR TITLE
Allow Storage of Builds When Filtered

### DIFF
--- a/BuildLibrary/BuildLibrary.cs
+++ b/BuildLibrary/BuildLibrary.cs
@@ -140,6 +140,13 @@ namespace GW2BuildLibrary
         }
 
         /// <summary>
+        /// Get the next free index available for storage.
+        /// </summary>
+        /// <returns>The next free index.</returns>
+        public int GetNextFreeIndex() =>
+            BuildTemplates.Values.Max(bt => bt.Index) + 1;
+
+        /// <summary>
         /// Loads the build library.
         /// </summary>
         public void Load() =>

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -313,8 +313,9 @@ namespace GW2BuildLibrary
             int pageOffset = BuildTemplateItems.ItemCount * (CurrentPage - 1);
             if (ProfessionFilter == Profession.None)
             {
-                // No filter applied so just show the builds as is All models are used and blank ones allow for storing
-                // more builds
+                /* No filter applied so just show the builds as they are
+                 * All models are used and empty ones allow for storing more builds
+                 */
                 for (int modelIndex = 0; modelIndex < BuildTemplateItems.ItemCount; modelIndex++)
                 {
                     BuildTemplateViewModel model = BuildTemplateModels[modelIndex];
@@ -341,10 +342,22 @@ namespace GW2BuildLibrary
                     model.IsHidden = false;
                 }
 
+                // Ensure there is an empty slot after the filtered results if there is room
+                if (modelIndex < BuildTemplateModels.Count)
+                {
+                    BuildTemplateViewModel model = BuildTemplateModels[modelIndex];
+                    model.BuildTemplate = null;
+                    model.Index = BuildLibrary.GetNextFreeIndex();
+                    model.IsHidden = false;
+                    modelIndex++;
+                }
+
                 // Instead of deleting models, tell them to hide
                 for (; modelIndex < BuildTemplateItems.ItemCount; modelIndex++)
                 {
-                    BuildTemplateModels[modelIndex].IsHidden = true;
+                    BuildTemplateViewModel model = BuildTemplateModels[modelIndex];
+                    model.IsHidden = true;
+                    model.BuildTemplate = null;
                 }
             }
         }

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -98,10 +98,7 @@ namespace GW2BuildLibrary
             if (BuildLibrary != null)
             {
                 if (BuildLibrary.Settings.ProfessionFilter != Profession.None)
-                {
                     ProfessionFilter = BuildLibrary.Settings.ProfessionFilter;
-                    // TODO Hide filter buttons
-                }
 
                 if (BuildLibrary.Settings.OverlayMode)
                 {

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -22,7 +22,8 @@ namespace GW2BuildLibrary
         /// Backing <see cref="DependencyProperty"/> for <see cref="BuildTemplateModels"/>.
         /// </summary>
         public static readonly DependencyProperty BuildTemplateModelsProperty =
-            DependencyProperty.Register("BuildTemplateModels", typeof(ObservableCollection<BuildTemplateViewModel>), typeof(MainWindow), new PropertyMetadata(new ObservableCollection<BuildTemplateViewModel>()));
+            DependencyProperty.Register("BuildTemplateModels", typeof(ObservableCollection<BuildTemplateViewModel>),
+                typeof(MainWindow), new PropertyMetadata(new ObservableCollection<BuildTemplateViewModel>()));
 
         /// <summary>
         /// Backing <see cref="DependencyProperty"/> for <see cref="CurrentPage"/>.
@@ -40,7 +41,8 @@ namespace GW2BuildLibrary
         /// Backing <see cref="DependencyProperty"/> for <see cref="ProfessionFilter"/>.
         /// </summary>
         public static readonly DependencyProperty ProfessionFilterProperty =
-            DependencyProperty.Register("ProfessionFilter", typeof(Profession), typeof(MainWindow), new PropertyMetadata(Profession.None));
+            DependencyProperty.Register("ProfessionFilter", typeof(Profession), typeof(MainWindow),
+                new PropertyMetadata(Profession.None));
 
         /// <summary>
         /// Clears the build template out of the slot.


### PR DESCRIPTION
This PR adds logic to ensure that there is an empty slot available for the storage of new builds when the library is being filtered to a specific profession.
We achieve this by calling to the library for the next available index and setting the next model along to be an empty one with that index.